### PR TITLE
feat: main page background에 naver map 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,9 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script
+      type="text/javascript"
+      src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=%VITE_CLIENT_ID%"
+    ></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "han-cycle",
       "version": "0.0.0",
       "dependencies": {
+        "@types/navermaps": "^3.7.5",
         "autoprefixer": "^10.4.19",
         "axios": "^1.7.2",
         "dotenv": "^16.4.5",
@@ -1072,6 +1073,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -1430,12 +1444,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/navermaps": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.7.5.tgz",
+      "integrity": "sha512-RzqYi0K5xhs45+KLkeoWjz2niDjVwKMYS1/LKns2LH9L7LEMVabdmyhP7n/6fzdJnbHc1wD1Dz+lFKOgq4yzJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
@@ -2137,6 +2166,15 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -5931,6 +5969,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -5938,6 +5988,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -6276,6 +6339,36 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.31.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.2.tgz",
+      "integrity": "sha512-LGyRZVFm/QElZHy/CPr/O4eNZOZIzsrQ92y4v9UJe/pFJjypje2yI3C2FmPtvUEnhadlSbmG2nXtdcjHOjCfxw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/navermaps": "^3.7.5",
     "autoprefixer": "^10.4.19",
     "axios": "^1.7.2",
     "dotenv": "^16.4.5",

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -5,7 +5,7 @@ const Layout = () => {
   return (
     <div className='flex min-h-screen w-screen'>
       <NavBar />
-      <div>
+      <div className='grow'>
         <Outlet />
       </div>
     </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,19 @@
+import { useEffect } from 'react';
+
 const HomePage = () => {
-  return <div>HomePage</div>;
+  useEffect(() => {
+    const mapOptions = {
+      center: new naver.maps.LatLng(36.3595704, 127.105399),
+      zoom: 7,
+      disableDoubleClickZoom: true,
+      disableDoubleTapZoom: true,
+      maxZoom: 13,
+      minZoom: 7,
+    };
+    const map = new naver.maps.Map('map', mapOptions);
+  }, []);
+
+  return <div id='map' className='h-full w-full'></div>;
 };
 
 export default HomePage;


### PR DESCRIPTION
**변경 사항 **

- main page background로 naver map을 지정했습니다.
- 한국내부 여행이 주제이기 때문에 지정된 범위보다 줌아웃 할 수 없습니다.
- center는 서울보다 살짝 아래로 지정했습니다.( 구체적인 위치는 모름. ui보고 조정했음. 그러지 않으면 평양이 너무 많이 보여서.. )
- map 인스턴스를 생성하고 컴포넌트의 id를 map으로 지정하면 해당 컴포넌트에 지도가 그려집니다.

**연결된 이슈**

close #1 

**변경 유형**

- [ ] 버그 수정 (기존 기능 수정)
- [x] 새로운 기능 추가
- [ ] 새로운 기능 삭제
- [ ] 기타 (문서/스타일 수정, 환경 변수, 빌드 관련 코드 업데이트 등)

**체크리스트**

- [x] 코드가 프로젝트의 스타일 가이드를 따릅니다.
- [ ] 변경 사항이 문서에 반영되었습니다.
- [ ] 관련된 이슈가 해결되었습니다.
