### PR TITLE
refactor: 컴포넌트 분리, map이 스크롤 될 때마다 재호출되던 문제 수정, zoom강도 수정

### DIFF
--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,0 +1,5 @@
+const Article = () => {
+  return <div>Article</div>;
+};
+
+export default Article;

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,0 +1,5 @@
+const Comment = () => {
+  return <div>Comment</div>;
+};
+
+export default Comment;

--- a/src/components/DropdownListContents.tsx
+++ b/src/components/DropdownListContents.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { locationList } from '../data/locationList';
+import { FaArrowRight } from 'react-icons/fa';
+
+interface DropdownListContentsProps {
+  startIndex: number;
+  lastIndex: number;
+  moveCenter: (name: string) => void;
+  clearMoveCenterTimeout: () => void;
+}
+
+const DropdownListContents: React.FC<DropdownListContentsProps> = ({
+  startIndex,
+  lastIndex,
+  moveCenter,
+  clearMoveCenterTimeout,
+}) => {
+  return (
+    <>
+      {locationList.slice(startIndex, lastIndex).map((item) => (
+        <Link to={`/community/${item.location_id}`} key={item.location_id}>
+          <li
+            className='group mb-2 flex items-center pl-4 font-chosun hover:bg-[#575757] hover:bg-opacity-10'
+            onMouseEnter={() => moveCenter(item.name)}
+            onMouseLeave={clearMoveCenterTimeout}
+          >
+            <img
+              className='mr-5 h-[21px] w-[21px]'
+              src={item.src}
+              alt={item.alt}
+            />
+            {item.name}
+            <FaArrowRight className='ml-auto mr-3 hidden text-xs group-hover:inline' />
+          </li>
+        </Link>
+      ))}
+    </>
+  );
+};
+
+export default DropdownListContents;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,47 +1,54 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import DropdownList from '../components/DropdownList';
 import { locationList } from '../data/locationList';
 
 const HomePage = () => {
-  const [map, setMap] = useState<naver.maps.Map | null>(null);
-  const centerX = 36.3595704;
-  const centerY = 127.105399;
+  const mapRef = useRef<naver.maps.Map | undefined>(undefined); // 초기 값을 undefined로 설정
+  const centerX = 36.0595704;
+  const centerY = 127.805399;
   const [marker, setMarker] = useState<naver.maps.Marker[] | null>(null);
 
   // 지도 생성
   useEffect(() => {
     const mapOptions = {
       center: new naver.maps.LatLng(centerX, centerY),
-      zoom: 7,
+      zoom: 8,
       disableDoubleClickZoom: true,
       disableDoubleTapZoom: true,
-      maxZoom: 12,
-      minZoom: 7,
+      maxZoom: 9,
+      minZoom: 8,
       tileSpare: 2,
     };
     const mapInstance = new naver.maps.Map('map', mapOptions);
-    setMap(mapInstance);
-  }, []);
+    mapRef.current = mapInstance;
 
-  // 마커생성하고 마커를 담은 배열을 state로 관리 -> dropdownlist로 넘겨서 list 특정지역 호버시 해당 지역의 마커 bound animation 줄 예정
-  useEffect(() => {
-    if (map) {
-      const MarkerArr = locationList.map((item) => {
-        return new naver.maps.Marker({
-          position: new naver.maps.LatLng(item.latitude, item.longitude),
-          map: map,
-          animation: naver.maps.Animation.DROP,
-          title: item.name,
-        });
+    // 마커 생성
+    const MarkerArr = locationList.map((item) => {
+      return new naver.maps.Marker({
+        position: new naver.maps.LatLng(item.latitude, item.longitude),
+        map: mapRef.current,
+        animation: naver.maps.Animation.DROP,
+        title: item.name,
       });
-      setMarker(MarkerArr);
-    }
-  }, [map]);
+    });
+    setMarker(MarkerArr);
+
+    // zoom 1씩 증가하고 감소하도록 지정
+    naver.maps.Event.addListener(mapRef.current, 'zoom_changed', () => {
+      if (mapRef.current) {
+        const newZoom = mapRef.current.getZoom();
+        mapRef.current.setOptions({
+          maxZoom: newZoom + 1,
+          minZoom: newZoom - 1,
+        });
+      }
+    });
+  }, []);
 
   return (
     <>
       <div id='map' className='relative h-full w-full'></div>
-      <DropdownList map={map} marker={marker}></DropdownList>
+      <DropdownList map={mapRef.current} marker={marker}></DropdownList>
     </>
   );
 };

--- a/src/pages/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage.tsx
@@ -1,5 +1,13 @@
+import Article from '../components/Article';
+import Comment from '../components/Comment';
+
 const PostDetailPage = () => {
-  return <div>PostDetailPage</div>;
+  return (
+    <>
+      <Article></Article>
+      <Comment></Comment>
+    </>
+  );
 };
 
 export default PostDetailPage;


### PR DESCRIPTION
**변경 사항 **

중복되는 컴포넌트를 분리하고, useState를 사용해서 map이 스크롤 될 때마다 재호출 되던 문제를 수정했습니다. 리랜더링을 불필요하게 발생시키는 요소들을 모두 useRef로 수정했습니다.

zoom이 한번에 3단계씩 되던 문제를 수정했습니다.

**연결된 이슈**

close #25 
close #26 

**변경 유형**

- [x] 버그 수정 (기존 기능 수정)
- [x] 새로운 기능 추가
- [ ] 새로운 기능 삭제
- [ ] 기타 (문서/스타일 수정, 환경 변수, 빌드 관련 코드 업데이트 등)

**체크리스트**

- [x] 코드가 프로젝트의 스타일 가이드를 따릅니다.
- [ ] 변경 사항이 문서에 반영되었습니다.
- [x] 관련된 이슈가 해결되었습니다.
