### PR TITLE
feat: post detail page scroll 내부에서 되도록 조정

### DIFF
--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -57,6 +57,11 @@ const Comment = () => {
   };
 
   const deleteComment = async (comment_id: number) => {
+    // 유저 정보가 일치할 때만 버튼이 보이도록 했지만, 혹~시~나~ 한번 더 막아주기
+    if (user?.user_id !== comment_id) {
+      setAlert('댓글 작성자만 삭제할 수 있습니다.');
+      return;
+    }
     try {
       await axios.delete(`/api/comments/${comment_id}`, {
         data: { user_id: user?.user_id },

--- a/src/pages/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage.tsx
@@ -3,10 +3,12 @@ import Comment from '../components/Comment';
 
 const PostDetailPage = () => {
   return (
-    <>
-      <Article></Article>
-      <Comment></Comment>
-    </>
+    <div className='h-screen overflow-hidden'>
+      <div className='h-full overflow-y-scroll'>
+        <Article />
+        <Comment />
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
**변경 사항 **

nav바의 scroll이 검색창 내부에서 이뤄지고 있어서, 외부에서 스크롤을 할 경우 nav bar 하단에 여백이 생기게 됩니다. 그래서 nav바의 오른편에 위치하는 dom 요소들도 내부에서 스크롤이 이루어져야하기 때문에 div 설정을 추가했습니다.

**연결된 이슈**

close #39 

**변경 유형**

- [ ] 버그 수정 (기존 기능 수정)
- [x] 새로운 기능 추가
- [ ] 새로운 기능 삭제
- [ ] 기타 (문서/스타일 수정, 환경 변수, 빌드 관련 코드 업데이트 등)

**체크리스트**

- [x] 코드가 프로젝트의 스타일 가이드를 따릅니다.
- [ ] 변경 사항이 문서에 반영되었습니다.
- [ ] 관련된 이슈가 해결되었습니다.
