### PR TITLE
feat: 댓글 수정 기능 추가+ 스웨거 기준으로 요청 url, body data 변경

### DIFF
--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,11 +1,12 @@
 import { useParams } from 'react-router-dom';
 import PostsData from '../data/posts.json';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAlertStore, useUserStore } from '../../config/store';
 import Alert from './common/Alert';
 import axios from 'axios';
 import { useForm, SubmitHandler } from 'react-hook-form';
 
+// 스웨거 보고 응답형태로 변환 필요.
 interface Comment {
   comment_id: number;
   user_id: number;
@@ -22,70 +23,106 @@ const Comment = () => {
   const [comments, setComments] = useState<Comment[] | undefined>(undefined);
   const { user } = useUserStore();
   const { setAlert } = useAlertStore();
-  const { register, handleSubmit, reset } = useForm<FormData>();
+  const {
+    register: createRegister,
+    handleSubmit: handleCreateSubmit,
+    reset: resetCreateForm,
+  } = useForm<FormData>();
+  const {
+    register: editRegister,
+    handleSubmit: handleEditSubmit,
+    reset: resetEditForm,
+    setValue: setEditValue,
+  } = useForm<FormData>();
+  const postId = useRef<number | undefined>();
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
 
   useEffect(() => {
+    postId.current = Number(param.post_id);
     const post = PostsData.find((item) => {
-      const id = Number(param.post_id);
-      return item.post_id === id;
+      return item.post_id === postId.current;
     });
     if (post) {
       setComments(post.comments);
     }
-  }, []);
+  }, [param.post_id]);
+
+  const updateComments = async () => {
+    try {
+      const response = await axios.get(`/posts/${postId.current}`);
+      setComments(response.data.comments);
+      resetCreateForm();
+      resetEditForm();
+    } catch (error) {
+      setAlert('댓글 업데이트에 실패했습니다.');
+    }
+  };
 
   const createComment: SubmitHandler<FormData> = async (data) => {
     if (user === null) {
       setAlert('로그인을 먼저 해주세요.');
       return;
     }
-
     try {
-      // 서버에 댓글 생성 요청
-      const response = await axios.post('/api/comments', {
+      await axios.post(`/posts/${postId.current}/comments`, {
         user_id: user.user_id,
-        post_id: param.post_id,
-        comment: data.comment,
+        content: data.comment,
       });
-      // 서버에서 최신 댓글 리스트를 받아와서 상태 업데이트
-      const updatedComments = response.data.comments;
-      setComments(updatedComments);
-      reset();
+      updateComments();
     } catch (error) {
       setAlert('댓글 작성에 실패했습니다.');
     }
   };
 
   const deleteComment = async (comment_id: number) => {
-    // 유저 정보가 일치할 때만 버튼이 보이도록 했지만, 혹~시~나~ 한번 더 막아주기
     if (user?.user_id !== comment_id) {
       setAlert('댓글 작성자만 삭제할 수 있습니다.');
       return;
     }
     try {
-      await axios.delete(`/api/comments/${comment_id}`, {
-        data: { user_id: user?.user_id },
+      // delete에 body..?
+      await axios.delete(`/posts/comments/${comment_id}`, {
+        data: {
+          user_id: user.user_id,
+        },
       });
-
-      // 댓글 삭제 후 서버에서 최신 댓글 리스트를 받아와서 상태 업데이트
-      const response = await axios.get(`/api/posts/${param.post_id}/comments`);
-      const updatedComments = response.data.comments;
-      setComments(updatedComments);
+      updateComments();
     } catch (error) {
       setAlert('댓글 삭제에 실패했습니다.');
     }
   };
 
+  const startEditComment = (comment_id: number, comment: string) => {
+    setEditingCommentId(comment_id);
+    setEditValue('comment', comment);
+  };
+
+  const saveEditComment: SubmitHandler<FormData> = async (data) => {
+    try {
+      await axios.put(`/posts/comments/${editingCommentId}`, {
+        content: data.comment,
+        user_id: user?.user_id,
+      });
+      setEditingCommentId(null);
+      updateComments();
+    } catch (error) {
+      setAlert('댓글 수정에 실패했습니다.');
+    }
+  };
+
+  const cancelEditComment = () => {
+    setEditingCommentId(null);
+  };
+
   return (
     <div className='mx-auto min-w-[1052px] max-w-[1052px]'>
-      <Alert></Alert>
+      <Alert />
       <div className='ml-2 text-[18px]'>
         {comments ? `${comments?.length}개의 댓글` : '0개의 댓글'}
       </div>
-      <form onSubmit={handleSubmit(createComment)}>
+      <form onSubmit={handleCreateSubmit(createComment)}>
         <textarea
-          {...register('comment', { required: true })}
-          name='comment'
+          {...createRegister('comment', { required: true })}
           className='my-3 h-[108px] w-full resize-none rounded-[10px] border border-solid border-[#7e7e7e] bg-[#d9d9d9] bg-opacity-[33%] p-4 outline-none'
           placeholder='댓글을 작성해주세요'
         ></textarea>
@@ -104,16 +141,54 @@ const Comment = () => {
               </div>
               <div className='m-2 text-[#777777]'>{comment.created_at}</div>
             </div>
-            {user?.user_id === comment.user_id ? (
-              <button
-                className='m-2 text-[13px] text-red-400'
-                onClick={() => deleteComment(comment.comment_id)}
-              >
-                삭제
-              </button>
-            ) : null}
+            {user?.user_id === comment.user_id && (
+              <div>
+                {editingCommentId === comment.comment_id ? (
+                  <>
+                    <button
+                      className='m-2 text-[13px] text-blue-400'
+                      onClick={handleEditSubmit(saveEditComment)}
+                    >
+                      저장
+                    </button>
+                    <button
+                      className='m-2 text-[13px] text-red-400'
+                      onClick={cancelEditComment}
+                    >
+                      취소
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button
+                      className='m-2 text-[13px] text-blue-400'
+                      onClick={() =>
+                        startEditComment(comment.comment_id, comment.comment)
+                      }
+                    >
+                      수정
+                    </button>
+                    <button
+                      className='m-2 text-[13px] text-red-400'
+                      onClick={() => deleteComment(comment.comment_id)}
+                    >
+                      삭제
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
           </div>
-          <div className='py-3'>{comment.comment}</div>
+          {editingCommentId === comment.comment_id ? (
+            <form onSubmit={handleEditSubmit(saveEditComment)}>
+              <textarea
+                {...editRegister('comment')}
+                className='h-[108px] w-full flex-grow resize-none border p-2'
+              />
+            </form>
+          ) : (
+            <div className='py-3'>{comment.comment}</div>
+          )}
         </div>
       ))}
     </div>


### PR DESCRIPTION
**변경 사항 **

댓글 수정 기능이 없는줄 알았는데! api 문서를 봤더니 있어서! 수정 기능도 추가했습니다.  댓글을 제출하는 form이 두개가 되어서, useForm도 두개를 개별로 불러와야 합니다.

오늘 스웨거가 배포되어서, 스웨거를 기준으로 url과 body의 data를 수정했습니다.

**연결된 이슈**

close #49

**변경 유형**

- [ ] 버그 수정 (기존 기능 수정)
- [x] 새로운 기능 추가
- [ ] 새로운 기능 삭제
- [ ] 기타 (문서/스타일 수정, 환경 변수, 빌드 관련 코드 업데이트 등)

**체크리스트**

- [x] 코드가 프로젝트의 스타일 가이드를 따릅니다.
- [ ] 변경 사항이 문서에 반영되었습니다.
- [ ] 관련된 이슈가 해결되었습니다.
