### PR TITLE
feat: comment white space 추가, outline 제거

### DIFF
--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -239,11 +239,11 @@ const Comment: React.FC<CommentProps> = ({ comments: initialComments }) => {
               <form onSubmit={handleEditSubmit(saveEditComment)}>
                 <textarea
                   {...editRegister('comment')}
-                  className='h-[108px] w-full flex-grow resize-none border p-2'
+                  className='h-[108px] w-full flex-grow resize-none border p-2 outline-none'
                 />
               </form>
             ) : (
-              <div className='py-3'>{comment.content}</div>
+              <p className='whitespace-pre-wrap py-3'>{comment.content}</p>
             )}
           </div>
         ))}


### PR DESCRIPTION
**변경 사항 **

textarea에는 \n = 다음줄이 기록으로 남지만, `<p>`나 `<div>`태그에서는 기본적으로는 다음줄을 제공하지 않는다. 그래서 whitespce옵션을 추가해야하고, 댓글을 수정 할 때 textarea의 outline 스타일을 제거했다.

**연결된 이슈**

close #107 

**변경 유형**

- [ ] 버그 수정 (기존 기능 수정)
- [x] 새로운 기능 추가
- [ ] 새로운 기능 삭제
- [ ] 기타 (문서/스타일 수정, 환경 변수, 빌드 관련 코드 업데이트 등)

**체크리스트**

- [x] 코드가 프로젝트의 스타일 가이드를 따릅니다.
- [ ] 변경 사항이 문서에 반영되었습니다.
- [x] 관련된 이슈가 해결되었습니다.
